### PR TITLE
ChainlinkRateProviderFactory

### DIFF
--- a/contracts/BaseRateProviderFactory.sol
+++ b/contracts/BaseRateProviderFactory.sol
@@ -31,6 +31,7 @@ contract BaseRateProviderFactory is IBaseRateProviderFactory {
     event RateProviderCreated(address indexed rateProvider);
     event FactoryDisabled();
 
+    // TODO: Implement Authentication
     constructor(address authorizer) {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/contracts/BaseRateProviderFactory.sol
+++ b/contracts/BaseRateProviderFactory.sol
@@ -26,33 +26,10 @@ import "./interfaces/IBaseRateProviderFactory.sol";
 contract BaseRateProviderFactory is IBaseRateProviderFactory {
     // Mapping of rate providers created by this factory.
     mapping(address => bool) internal _factoryCreatedRateProviders;
-    bool private _disabled;
 
     event RateProviderCreated(address indexed rateProvider);
-    event FactoryDisabled();
-
-    // TODO: Implement Authentication
-    constructor(address authorizer) {
-        // solhint-disable-previous-line no-empty-blocks
-    }
 
     function isRateProviderFromFactory(address rateProvider) external view returns (bool) {
         return _factoryCreatedRateProviders[rateProvider];
-    }
-
-    function isDisabled() public view override returns (bool) {
-        return _disabled;
-    }
-
-    function disable() external override {
-        _ensureEnabled();
-
-        _disabled = true;
-
-        emit FactoryDisabled();
-    }
-
-    function _ensureEnabled() internal view {
-        require(!isDisabled(), "Factory disabled");
     }
 }

--- a/contracts/BaseRateProviderFactory.sol
+++ b/contracts/BaseRateProviderFactory.sol
@@ -32,4 +32,9 @@ contract BaseRateProviderFactory is IBaseRateProviderFactory {
     function isRateProviderFromFactory(address rateProvider) external view returns (bool) {
         return _factoryCreatedRateProviders[rateProvider];
     }
+
+    function _onCreate(address rateProvider) internal {
+        _factoryCreatedRateProviders[rateProvider] = true;
+        emit RateProviderCreated(rateProvider);
+    }
 }

--- a/contracts/BaseRateProviderFactory.sol
+++ b/contracts/BaseRateProviderFactory.sol
@@ -23,16 +23,16 @@ import "./interfaces/IBaseRateProviderFactory.sol";
  */
 contract BaseRateProviderFactory is IBaseRateProviderFactory {
     // Mapping of rate providers created by this factory.
-    mapping(address => bool) private _factoryCreatedRateProviders;
+    mapping(address => bool) private _isRateProviderFromFactory;
 
     event RateProviderCreated(address indexed rateProvider);
 
     function isRateProviderFromFactory(address rateProvider) external view returns (bool) {
-        return _factoryCreatedRateProviders[rateProvider];
+        return _isRateProviderFromFactory[rateProvider];
     }
 
     function _onCreate(address rateProvider) internal {
-        _factoryCreatedRateProviders[rateProvider] = true;
+        _isRateProviderFromFactory[rateProvider] = true;
         emit RateProviderCreated(rateProvider);
     }
 }

--- a/contracts/BaseRateProviderFactory.sol
+++ b/contracts/BaseRateProviderFactory.sol
@@ -17,15 +17,13 @@ pragma solidity ^0.8.0;
 import "./interfaces/IBaseRateProviderFactory.sol";
 
 /**
- * @title Chainlink Rate Provider Factory
- * @notice Factory for creating ChainlinkRateProviders
- * @dev This contract is used to create ChainlinkRateProvider contracts.
- *      RateProviders created by this factory are to be used in environments
- *      where the Chainlink registry is not available.
+ * @title Base Rate Provider Factory
+ * @notice Base Factory for creating RateProviders
+ * @dev This is a base contract for building factories that create RateProviders.
  */
 contract BaseRateProviderFactory is IBaseRateProviderFactory {
     // Mapping of rate providers created by this factory.
-    mapping(address => bool) internal _factoryCreatedRateProviders;
+    mapping(address => bool) private _factoryCreatedRateProviders;
 
     event RateProviderCreated(address indexed rateProvider);
 

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -30,27 +30,27 @@ contract ChainlinkRateProviderFactory {
     // Mapping of rate providers created by this factory.
     mapping (address => bool) private _factoryCreatedRateProviders;
 
-    event ChainlinkRateProviderCreated(address indexed provider);
+    event ChainlinkRateProviderCreated(address indexed rateProvider);
 
     /**
      * @notice Deploys a new ChainlinkRateProvider contract using a price feed.
      * @param feed - The Chainlink price feed contract.
      */
     function create(AggregatorV3Interface feed) external returns (ChainlinkRateProvider) {
-        ChainlinkRateProvider provider = new ChainlinkRateProvider(feed);
-        _factoryCreatedRateProviders[address(provider)] = true;
+        ChainlinkRateProvider rateProvider = new ChainlinkRateProvider(feed);
+        _factoryCreatedRateProviders[address(rateProvider)] = true;
 
-        emit ChainlinkRateProviderCreated(address(provider));
+        emit ChainlinkRateProviderCreated(address(rateProvider));
         
-        return provider;
+        return rateProvider;
     }
 
     /**
      * @notice Checks if a rate provider was created by this factory.
-     * @param provider - Address of the rate provider to check.
+     * @param rateProvider - Address of the rate provider to check.
      * @return bool - True if the rate provider was created by this factory.
      */
-    function isRateProviderFromFactory(address provider) external view returns (bool) {
-        return _factoryCreatedRateProviders[provider];
+    function isRateProviderFromFactory(address rateProvider) external view returns (bool) {
+        return _factoryCreatedRateProviders[rateProvider];
     }
 }

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -34,7 +34,6 @@ contract ChainlinkRateProviderFactory is BaseRateProviderFactory {
     function create(AggregatorV3Interface feed) external returns (ChainlinkRateProvider) {
         ChainlinkRateProvider rateProvider = new ChainlinkRateProvider(feed);
         _onCreate(address(rateProvider));
-
         return rateProvider;
     }
 }

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -14,6 +14,25 @@
 
 pragma solidity ^0.8.0;
 
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+import "./ChainlinkRateProvider.sol";
+
 contract ChainlinkRateProviderFactory {
-    
+    mapping (address => bool) private _factoryCreatedRateProviders;
+
+    event ChainlinkRateProviderCreated(address indexed provider);
+
+    function create(AggregatorV3Interface feed) external returns (ChainlinkRateProvider) {
+        ChainlinkRateProvider provider = new ChainlinkRateProvider(feed);
+        _factoryCreatedRateProviders[address(provider)] = true;
+        
+        emit ChainlinkRateProviderCreated(address(provider));
+        
+        return provider;
+    }
+
+    function isRateProviderFromFactory(address provider) external view returns (bool) {
+        return _factoryCreatedRateProviders[provider];
+    }
 }

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -18,20 +18,38 @@ import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 import "./ChainlinkRateProvider.sol";
 
+/**
+ * @title Chainlink Rate Provider Factory
+ * @notice Factory for creating ChainlinkRateProviders
+ * @dev This contract is used to create ChainlinkRateProvider contracts.
+ *      RateProviders created by this factory are to be used in environments 
+ *      where the Chainlink registry is not available.
+ */
+
 contract ChainlinkRateProviderFactory {
+    // Mapping of rate providers created by this factory.
     mapping (address => bool) private _factoryCreatedRateProviders;
 
     event ChainlinkRateProviderCreated(address indexed provider);
 
+    /**
+     * @notice Deploys a new ChainlinkRateProvider contract using a price feed.
+     * @param feed - The Chainlink price feed contract.
+     */
     function create(AggregatorV3Interface feed) external returns (ChainlinkRateProvider) {
         ChainlinkRateProvider provider = new ChainlinkRateProvider(feed);
         _factoryCreatedRateProviders[address(provider)] = true;
-        
+
         emit ChainlinkRateProviderCreated(address(provider));
         
         return provider;
     }
 
+    /**
+     * @notice Checks if a rate provider was created by this factory.
+     * @param provider - Address of the rate provider to check.
+     * @return bool - True if the rate provider was created by this factory.
+     */
     function isRateProviderFromFactory(address provider) external view returns (bool) {
         return _factoryCreatedRateProviders[provider];
     }

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -22,13 +22,13 @@ import "./ChainlinkRateProvider.sol";
  * @title Chainlink Rate Provider Factory
  * @notice Factory for creating ChainlinkRateProviders
  * @dev This contract is used to create ChainlinkRateProvider contracts.
- *      RateProviders created by this factory are to be used in environments 
+ *      RateProviders created by this factory are to be used in environments
  *      where the Chainlink registry is not available.
  */
 
 contract ChainlinkRateProviderFactory {
     // Mapping of rate providers created by this factory.
-    mapping (address => bool) private _factoryCreatedRateProviders;
+    mapping(address => bool) private _factoryCreatedRateProviders;
 
     event ChainlinkRateProviderCreated(address indexed rateProvider);
 
@@ -41,7 +41,7 @@ contract ChainlinkRateProviderFactory {
         _factoryCreatedRateProviders[address(rateProvider)] = true;
 
         emit ChainlinkRateProviderCreated(address(rateProvider));
-        
+
         return rateProvider;
     }
 

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+contract ChainlinkRateProviderFactory {
+    
+}

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -27,7 +27,7 @@ import "./ChainlinkRateProvider.sol";
  *      where the Chainlink registry is not available.
  */
 contract ChainlinkRateProviderFactory is BaseRateProviderFactory {
-    constructor(address authorizer) BaseRateProviderFactory(authorizer) {
+    constructor() BaseRateProviderFactory() {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -36,8 +36,6 @@ contract ChainlinkRateProviderFactory is BaseRateProviderFactory {
      * @param feed - The Chainlink price feed contract.
      */
     function create(AggregatorV3Interface feed) external returns (ChainlinkRateProvider) {
-        _ensureEnabled();
-
         ChainlinkRateProvider rateProvider = new ChainlinkRateProvider(feed);
         _factoryCreatedRateProviders[address(rateProvider)] = true;
 

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -33,9 +33,7 @@ contract ChainlinkRateProviderFactory is BaseRateProviderFactory {
      */
     function create(AggregatorV3Interface feed) external returns (ChainlinkRateProvider) {
         ChainlinkRateProvider rateProvider = new ChainlinkRateProvider(feed);
-        _factoryCreatedRateProviders[address(rateProvider)] = true;
-
-        emit RateProviderCreated(address(rateProvider));
+        _onCreate(address(rateProvider));
 
         return rateProvider;
     }

--- a/contracts/ChainlinkRateProviderFactory.sol
+++ b/contracts/ChainlinkRateProviderFactory.sol
@@ -27,10 +27,6 @@ import "./ChainlinkRateProvider.sol";
  *      where the Chainlink registry is not available.
  */
 contract ChainlinkRateProviderFactory is BaseRateProviderFactory {
-    constructor() BaseRateProviderFactory() {
-        // solhint-disable-previous-line no-empty-blocks
-    }
-
     /**
      * @notice Deploys a new ChainlinkRateProvider contract using a price feed.
      * @param feed - The Chainlink price feed contract.

--- a/contracts/interfaces/IBaseRateProviderFactory.sol
+++ b/contracts/interfaces/IBaseRateProviderFactory.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+interface IBaseRateProviderFactory {
+    /**
+     * @dev Checks if a rate provider was created by the derived factory.
+     * @param rateProvider - Address of the rate provider to check.
+     * @return bool - True if the rate provider was created by the derived factory.
+     */
+    function isRateProviderFromFactory(address rateProvider) external view returns (bool);
+
+    /**
+     * @dev Check whether the derived factory has been disabled.
+     */
+    function isDisabled() external view returns (bool);
+
+    /**
+     * @dev Disable the factory, preventing the creation of more pools. Already existing pools are unaffected.
+     * Once a factory is disabled, it cannot be re-enabled.
+     */
+    function disable() external;
+}

--- a/contracts/interfaces/IBaseRateProviderFactory.sol
+++ b/contracts/interfaces/IBaseRateProviderFactory.sol
@@ -21,15 +21,4 @@ interface IBaseRateProviderFactory {
      * @return bool - True if the rate provider was created by the derived factory.
      */
     function isRateProviderFromFactory(address rateProvider) external view returns (bool);
-
-    /**
-     * @dev Check whether the derived factory has been disabled.
-     */
-    function isDisabled() external view returns (bool);
-
-    /**
-     * @dev Disable the factory, preventing the creation of more pools. Already existing pools are unaffected.
-     * Once a factory is disabled, it cannot be re-enabled.
-     */
-    function disable() external;
 }


### PR DESCRIPTION
Factory for deploying ChainlinkRateProviders.

Functions:
`create` - Deploys a ChainlinkRateProvider that uses a Chainlink AggregatorV3Interface price feed.
`isRateProviderFromFactory` - Checks if a rate provider was deployed using this factory contract.

Events:
`ChainlinkRateProviderCreate(address indexed provider)` - Event emitted upon new rate provider deployments.