### PR TITLE
CombinedRateProviderFactory

### DIFF
--- a/contracts/CombinedRateProvider.sol
+++ b/contracts/CombinedRateProvider.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+import "./interfaces/IRateProvider.sol";
+
+contract CombinedRateProvider {
+    address public rateProvider1;
+    address public rateProvider2;
+
+    constructor(address _rateProvider1, address _rateProvider2) {
+        rateProvider1 = _rateProvider1;
+        rateProvider2 = _rateProvider2;
+    }
+
+    // Function to combine both of the rate providers via multiplication
+    function getRate() external view returns (uint256) {
+        // rateProvider1 and rateProvider2 must respect the proper interface.
+        uint256 rate1 = IRateProvider(rateProvider1).getRate();
+        uint256 rate2 = IRateProvider(rateProvider2).getRate();
+        return rate1 * rate2 / 1e18; // Multiplies the rates respecting the proper interface together and divides by 1e18 to normalize.
+    }
+}

--- a/contracts/CombinedRateProviderFactory.sol
+++ b/contracts/CombinedRateProviderFactory.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+import "./BaseRateProviderFactory.sol";
+import "./CombinedRateProvider.sol";
+
+/**
+ * @title  Combined Rate Provider Factory
+ * @notice This contract is a factory for creating instances of CombinedRateProvider.
+ * @dev    This factory contract allows for the deployment of CombinedRateProvider contracts, 
+ *         which are used to combine market rates from two individual rate providers.
+ */
+
+
+contract CombinedRateProviderFactory is BaseRateProviderFactory {
+    /**
+     * @notice Deploys a new CombinedRateProvider contract using a price feed.
+     * @param _rateProvider1 - The first of two rate providers the user wishes to multiply
+     * @param _rateProvider2 - The second of two rate providers the user wishes to multiply
+     */
+    function create(address _rateProvider1, address _rateProvider2) external returns (CombinedRateProvider) {
+        CombinedRateProvider rateProvider = new CombinedRateProvider(_rateProvider1, _rateProvider2);
+        _onCreate(address(rateProvider));
+        return rateProvider;
+    }
+}


### PR DESCRIPTION
Adds contract for CombinedRateProviderFactorty and CombinedRateProvider. The purpose of these contracts is to combined two rates in scenarios where the common denomination of assets is not uniform. For example, a rate provider denominated in wstETH and another in wETH cannot be used in a pool pairing. Combining the wstETH denominated rate with wstETH's known rate provider solves this issue with a new contract.

Verified Deployments: 

Base
Factory: https://basescan.org/address/0x40b48e1eb72c62f7201b4c2621df7d822ccb9944#code 
Deployment https://basescan.org/address/0xbB44C335593C79b4807cb76e5EBC3a4fF5c9b8B8#code 

OP
Factory: https://optimistic.etherscan.io/address/0x7d9507014cc564e3b95e4d0972a878d0862af7ae
Deployment: https://optimistic.etherscan.io/address/0x75ab951aec0ff692225e440f96d3f5a16befac3b 

Arbitrum
Factory: https://arbiscan.io/address/0x26dec0e6a4249f28e0f16a1a79808bf9ba308310#code 
Deployment: https://arbiscan.io/address/0x998DE64cB90EdF3d205CFDB864E199fDA4d55710#code

Mainnet
Factory https://etherscan.io/address/0xd2cd8027f8c4b8ddcd1bfcd4e47587f41f2712f2 
Deployment https://etherscan.io/address/0x3ba1a97D96F53611C4b2A788A5aa65c840d94c54 
